### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "php_cli"
+run = "PHP CLI"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BrowserQuest-PHP
 BrowserQuest server in PHP
-
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/BrowserQuest-PHP)](https://repl.it/github/UzayAnil/BrowserQuest-PHP)
 ![BrowserQuest width workerman](https://github.com/walkor/BrowserQuest-PHP/blob/master/Web/img/screenshot.jpg?raw=true)
 
 ## 安装 － Install


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@UzayAnil/BrowserQuest-PHP).